### PR TITLE
fix: reset auth state on logout

### DIFF
--- a/src/composants/AuthContext.tsx
+++ b/src/composants/AuthContext.tsx
@@ -18,8 +18,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         const stored = localStorage.getItem(key);
         return stored !== null ? stored : defaultValue;
     };
-    const [user, setUser] = useState<string>(() => loadFromStorage("user", null));
-    const [token, setToken] = useState<string>(() => loadFromStorage("token", null));
+    const [user, setUser] = useState<string | null>(() => loadFromStorage("user", null));
+    const [token, setToken] = useState<string | null>(() => loadFromStorage("token", null));
     const navigate = useNavigate();
     const { setSelectedGenres, setSelectedProviders } = useNetfluxContext();
 
@@ -62,8 +62,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const logout = () => {
         localStorage.removeItem("token");
         localStorage.removeItem("user");
-        setSelectedGenres([])
-        setSelectedProviders([])
+        setToken(null);
+        setUser(null);
+        setSelectedGenres([]);
+        setSelectedProviders([]);
         navigate("/login");
     };
 


### PR DESCRIPTION
## Summary
- correctly type nullable auth fields
- clear user session state on logout to ensure proper authentication handling

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a592a2fba4832eb3330f3a4b573919